### PR TITLE
Fix errors in setup.py

### DIFF
--- a/dj_hetmech/settings.py
+++ b/dj_hetmech/settings.py
@@ -25,6 +25,9 @@ with open(path) as read_file:
 # Quick-start development settings - unsuitable for production
 # See https://docs.djangoproject.com/en/2.1/howto/deployment/checklist/
 
+# SECURITY WARNING: keep the secret key used in production secret!
+SECRET_KEY = 'secret_not_yet_set'
+
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True
 
@@ -81,8 +84,8 @@ WSGI_APPLICATION = 'dj_hetmech.wsgi.application'
 DATABASES = {
     'default': {
         'ENGINE': 'django.db.backends.postgresql_psycopg2',
-        'NAME': secrets['db']['name'],,
-        'USER': secrets['db']['user'],,
+        'NAME': secrets['db']['name'],
+        'USER': secrets['db']['user'],
         'PASSWORD': secrets['db']['password'],
         'HOST': secrets['db']['host'],
         'PORT': secrets['db']['port'],


### PR DESCRIPTION
Reverts errors introduced in
https://github.com/greenelab/hetmech-backend/commit/e72b7fc665f7ad7da0756a9dcaccc2cb0b4ac188

SECRET_KEY is not for the database and must exist or Django will
not start up.
https://docs.djangoproject.com/en/2.1/ref/settings/#std:setting-SECRET_KEY

Removes duplicate commas