### PR TITLE
Web API for Node search

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,10 +43,6 @@ jobs:
             python manage.py makemigrations dj_hetmech_app
             python manage.py migrate
             python manage.py test
-      - run:
-          name: Frontend tests
-          command: |
-            apt install nodejs npm libfontconfig --yes
 
 workflows:
   version: 2

--- a/dj_hetmech/settings.py
+++ b/dj_hetmech/settings.py
@@ -44,12 +44,22 @@ INSTALLED_APPS = [
     'django.contrib.messages',
     'django.contrib.staticfiles',
     'django_extensions',
+    'rest_framework',
+    'corsheaders',
     'dj_hetmech_app',
 ]
+
+REST_FRAMEWORK = {
+    'PAGE_SIZE': 25,
+    'DEFAULT_PAGINATION_CLASS': 'rest_framework.pagination.LimitOffsetPagination',
+    'DEFAULT_RENDERER_CLASSES': ('rest_framework.renderers.JSONRenderer', ),
+    'DEFAULT_FILTER_BACKENDS': ('django_filters.rest_framework.DjangoFilterBackend',)
+}
 
 MIDDLEWARE = [
     'django.middleware.security.SecurityMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
+    'corsheaders.middleware.CorsMiddleware',
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
@@ -130,3 +140,9 @@ USE_TZ = True
 # https://docs.djangoproject.com/en/2.1/howto/static-files/
 
 STATIC_URL = '/static/'
+
+# CORS config
+# https://pypi.org/project/django-cors-headers/
+CORS_ORIGIN_ALLOW_ALL = True
+CORS_URLS_REGEX = r'^/api/.*$'
+CORS_ALLOW_METHODS = ('GET', )

--- a/dj_hetmech/settings.py
+++ b/dj_hetmech/settings.py
@@ -52,8 +52,8 @@ INSTALLED_APPS = [
 REST_FRAMEWORK = {
     'PAGE_SIZE': 25,
     'DEFAULT_PAGINATION_CLASS': 'rest_framework.pagination.LimitOffsetPagination',
-    'DEFAULT_RENDERER_CLASSES': ('rest_framework.renderers.JSONRenderer', ),
-    'DEFAULT_FILTER_BACKENDS': ('django_filters.rest_framework.DjangoFilterBackend',)
+    'DEFAULT_RENDERER_CLASSES': ('rest_framework.renderers.JSONRenderer',),
+    'DEFAULT_FILTER_BACKENDS': ('django_filters.rest_framework.DjangoFilterBackend',),
 }
 
 MIDDLEWARE = [

--- a/dj_hetmech/urls.py
+++ b/dj_hetmech/urls.py
@@ -14,8 +14,14 @@ Including another URLconf
     2. Add a URL to urlpatterns:  path('blog/', include('blog.urls'))
 """
 from django.contrib import admin
-from django.urls import path
+from django.urls import include, path, re_path
+from rest_framework import routers
+from dj_hetmech_app import views
+
+router = routers.DefaultRouter()
+router.register("nodes", views.NodeView)
 
 urlpatterns = [
     path('admin/', admin.site.urls),
+    path('api/v1/', include(router.urls)),
 ]

--- a/dj_hetmech_app/serializers.py
+++ b/dj_hetmech_app/serializers.py
@@ -1,0 +1,7 @@
+from rest_framework import serializers
+from .models import Node
+
+class NodeSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Node
+        fields = '__all__'

--- a/dj_hetmech_app/views.py
+++ b/dj_hetmech_app/views.py
@@ -1,3 +1,16 @@
 from django.shortcuts import render
+from rest_framework.viewsets import ModelViewSet
+from rest_framework import filters
+
+from .models import Node
+from .serializers import NodeSerializer
+
 
 # Create your views here.
+class NodeView(ModelViewSet):
+    http_method_names = ['get']
+
+    queryset = Node.objects.all()
+    serializer_class = NodeSerializer
+    filter_backends = (filters.SearchFilter,)
+    search_fields = ('identifier', 'metanode__identifier', 'name')

--- a/dj_hetmech_app/views.py
+++ b/dj_hetmech_app/views.py
@@ -1,4 +1,3 @@
-from django.shortcuts import render
 from rest_framework.viewsets import ModelViewSet
 from rest_framework import filters
 
@@ -7,6 +6,10 @@ from .serializers import NodeSerializer
 
 
 # Create your views here.
+
+# The view that shows node information.
+# See this page for "search" implementation and other filter options:
+# https://www.django-rest-framework.org/api-guide/filtering/
 class NodeView(ModelViewSet):
     http_method_names = ['get']
 

--- a/environment.yml
+++ b/environment.yml
@@ -2,9 +2,13 @@ name: hetmech-backend
 channels:
   - conda-forge
 dependencies:
-  - conda-forge::django-extensions=2.1.4
   - conda-forge::django=2.1.5
+  - conda-forge::django-cors-headers=2.4.0
+  - conda-forge::django-extensions=2.1.4
+  - conda-forge::django-filter=2.1.0
+  - conda-forge::djangorestframework=3.9.1
   - conda-forge::graphviz=2.38.0
+  - conda-forge::gunicorn=19.9.0
   - conda-forge::ipykernel=5.1.0
   - conda-forge::pandas=0.24.0
   - conda-forge::psycopg2=2.7.7


### PR DESCRIPTION
This PR adds a simple REST API that supports `Node` search. Here is an example:
http://34.233.249.241/api/v1/nodes/?search=abc

By default, it shows only 25 results. To get all of them, use the `limit` parameter:
http://34.233.249.241/api/v1/nodes/?search=abc&limit=100000

I also removed `frontend` test in CircleCI, because this repo is supposed to be backend only.