### PR TITLE
API: reverse metapath in querypair endpoint result

### DIFF
--- a/dj_hetmech_app/utils.py
+++ b/dj_hetmech_app/utils.py
@@ -1,3 +1,5 @@
+import functools
+
 
 def timed(func):
     """
@@ -5,7 +7,6 @@ def timed(func):
     https://gist.github.com/bradmontgomery/bd6288f09a24c06746bbe54afe4b8a82
     """
     import datetime
-    import functools
     import inspect
     import time
 
@@ -21,3 +22,221 @@ def timed(func):
         print(f'{func.__name__}({arg_str}) ran in {timedelta}')
         return result
     return wrapper
+
+
+@functools.lru_cache()
+def get_hetionet_metagraph():
+    """
+    https://github.com/hetio/hetionet/blob/b7c144da0dd428def9e3c262d0bc48c050cf631d/hetnet/json/hetionet-v1.0-metagraph.json
+    """
+    import json
+    from hetio.readwrite import metagraph_from_writable
+    hetionet_metagraph_json = '''
+    {
+    "metanode_kinds": [
+        "Anatomy",
+        "Biological Process",
+        "Cellular Component",
+        "Compound",
+        "Disease",
+        "Gene",
+        "Molecular Function",
+        "Pathway",
+        "Pharmacologic Class",
+        "Side Effect",
+        "Symptom"
+    ],
+    "metaedge_tuples": [
+        [
+        "Anatomy",
+        "Gene",
+        "downregulates",
+        "both"
+        ],
+        [
+        "Anatomy",
+        "Gene",
+        "expresses",
+        "both"
+        ],
+        [
+        "Anatomy",
+        "Gene",
+        "upregulates",
+        "both"
+        ],
+        [
+        "Compound",
+        "Compound",
+        "resembles",
+        "both"
+        ],
+        [
+        "Compound",
+        "Disease",
+        "palliates",
+        "both"
+        ],
+        [
+        "Compound",
+        "Disease",
+        "treats",
+        "both"
+        ],
+        [
+        "Compound",
+        "Gene",
+        "binds",
+        "both"
+        ],
+        [
+        "Compound",
+        "Gene",
+        "downregulates",
+        "both"
+        ],
+        [
+        "Compound",
+        "Gene",
+        "upregulates",
+        "both"
+        ],
+        [
+        "Compound",
+        "Side Effect",
+        "causes",
+        "both"
+        ],
+        [
+        "Disease",
+        "Anatomy",
+        "localizes",
+        "both"
+        ],
+        [
+        "Disease",
+        "Disease",
+        "resembles",
+        "both"
+        ],
+        [
+        "Disease",
+        "Gene",
+        "associates",
+        "both"
+        ],
+        [
+        "Disease",
+        "Gene",
+        "downregulates",
+        "both"
+        ],
+        [
+        "Disease",
+        "Gene",
+        "upregulates",
+        "both"
+        ],
+        [
+        "Disease",
+        "Symptom",
+        "presents",
+        "both"
+        ],
+        [
+        "Gene",
+        "Biological Process",
+        "participates",
+        "both"
+        ],
+        [
+        "Gene",
+        "Cellular Component",
+        "participates",
+        "both"
+        ],
+        [
+        "Gene",
+        "Gene",
+        "covaries",
+        "both"
+        ],
+        [
+        "Gene",
+        "Gene",
+        "interacts",
+        "both"
+        ],
+        [
+        "Gene",
+        "Gene",
+        "regulates",
+        "forward"
+        ],
+        [
+        "Gene",
+        "Molecular Function",
+        "participates",
+        "both"
+        ],
+        [
+        "Gene",
+        "Pathway",
+        "participates",
+        "both"
+        ],
+        [
+        "Pharmacologic Class",
+        "Compound",
+        "includes",
+        "both"
+        ]
+    ],
+    "kind_to_abbrev": {
+        "Biological Process": "BP",
+        "Cellular Component": "CC",
+        "causes": "c",
+        "Pharmacologic Class": "PC",
+        "Molecular Function": "MF",
+        "palliates": "p",
+        "downregulates": "d",
+        "expresses": "e",
+        "Gene": "G",
+        "covaries": "c",
+        "upregulates": "u",
+        "presents": "p",
+        "Anatomy": "A",
+        "Symptom": "S",
+        "Pathway": "PW",
+        "treats": "t",
+        "localizes": "l",
+        "Disease": "D",
+        "participates": "p",
+        "binds": "b",
+        "includes": "i",
+        "associates": "a",
+        "Compound": "C",
+        "interacts": "i",
+        "resembles": "r",
+        "regulates": "r",
+        "Side Effect": "SE"
+    }
+    }
+    '''
+    metagraph = metagraph_from_writable(json.loads(hetionet_metagraph_json))
+    return metagraph
+
+
+@functools.lru_cache(maxsize=10_000)
+def reverse_metapath(abbreviation):
+    """
+    Return abbreviation and name for the inverse of a metapath.
+    (the metapath in the reversed direction)
+    """
+    metagraph = get_hetionet_metagraph()
+    metapath = metagraph.metapath_from_abbrev(abbreviation)
+    inverse = metapath.inverse
+    return {
+        'metapath_abbreviation': inverse.abbrev,
+        'metapath_name': inverse.get_unicode_str(),
+    }

--- a/dj_hetmech_app/views.py
+++ b/dj_hetmech_app/views.py
@@ -48,6 +48,8 @@ class QueryPairView(APIView):
                 entry['source_degree'], entry['target_degree'] = (
                     entry['target_degree'], entry['source_degree']
                 )
+                from dj_hetmech_app.utils import reverse_metapath
+                entry.update(reverse_metapath(entry['metapath_abbreviation']))
 
             # Delete 'metapath', 'source' and 'target' fields
             del entry['metapath']


### PR DESCRIPTION
In #20 I forgot that we needed to also switch the direction of metapaths being returned. 