### PR TITLE
Remove DEFAULT_RENDERER_CLASSES setting

### DIFF
--- a/dj_hetmech/settings.py
+++ b/dj_hetmech/settings.py
@@ -53,7 +53,6 @@ INSTALLED_APPS = [
 REST_FRAMEWORK = {
     'PAGE_SIZE': 25,
     'DEFAULT_PAGINATION_CLASS': 'rest_framework.pagination.LimitOffsetPagination',
-    'DEFAULT_RENDERER_CLASSES': ('rest_framework.renderers.JSONRenderer',),
     'DEFAULT_FILTER_BACKENDS': ('django_filters.rest_framework.DjangoFilterBackend',),
 }
 

--- a/dj_hetmech/urls.py
+++ b/dj_hetmech/urls.py
@@ -13,16 +13,15 @@ Including another URLconf
     1. Import the include() function: from django.urls import include, path
     2. Add a URL to urlpatterns:  path('blog/', include('blog.urls'))
 """
-from django.contrib import admin
 from django.urls import path, include
 from rest_framework import routers
 from dj_hetmech_app import views
 
 router = routers.DefaultRouter()
-router.register("nodes", views.NodeView, basename="nodes")
+router.register("nodes", views.NodeViewSet, basename="node")
 
 urlpatterns = [
-    path('admin/', admin.site.urls),
+    path('v1/', views.api_root),
     path('v1/', include(router.urls)),
     path('v1/querypair/', views.QueryPairView.as_view(), name="query-pair"),
 ]

--- a/dj_hetmech_app/views.py
+++ b/dj_hetmech_app/views.py
@@ -14,7 +14,7 @@ from .serializers import NodeSerializer, PathCountDgpSerializer
 def api_root(request):
     return Response({
         'nodes': reverse('node-list', request=request),
-        'querypair': reverse('query-pair',  request=request)
+        'querypair': reverse('query-pair',  request=request),
     })
 
 

--- a/dj_hetmech_app/views.py
+++ b/dj_hetmech_app/views.py
@@ -1,18 +1,27 @@
 from django.db.models import Q
 from rest_framework import filters, status
+from rest_framework.decorators import api_view
 from rest_framework.response import Response
+from rest_framework.reverse import reverse
 from rest_framework.views import APIView
 from rest_framework.viewsets import ModelViewSet
 
 from .models import Node, PathCount
 from .serializers import NodeSerializer, PathCountDgpSerializer
 
-# Create your views here.
+
+@api_view(['GET'])
+def api_root(request):
+    return Response({
+        'nodes': reverse('node-list', request=request),
+        'querypair': reverse('query-pair',  request=request)
+    })
+
 
 # The view that shows node information.
 # See the following page for "search" implementation and other filter options:
 # https://www.django-rest-framework.org/api-guide/filtering/
-class NodeView(ModelViewSet):
+class NodeViewSet(ModelViewSet):
     http_method_names = ['get']
     serializer_class = NodeSerializer
     filter_backends = (filters.SearchFilter, )


### PR DESCRIPTION
When this setting is removed, the webpage of "https://search-api.het.io/v1/..." shown on the web browser will be in html format, which is much more user-friendly than JSON format.  