### PR TITLE
Fix static files path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,6 @@ __pycache__
 # System files
 *~
 .vscode
+
+# Directory of static files for backend server deployment
+dj_hetmech/static

--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,3 @@ __pycache__
 # System files
 *~
 .vscode
-
-# Directory of static files for backend server deployment
-dj_hetmech/static

--- a/dj_hetmech/settings.py
+++ b/dj_hetmech/settings.py
@@ -138,7 +138,7 @@ USE_TZ = True
 
 # Static files (CSS, JavaScript, Images)
 # https://docs.djangoproject.com/en/2.1/howto/static-files/
-STATIC_ROOT = "/home/ubuntu/hetmech-backend/dj_hetmech/static/"
+STATIC_ROOT = "/home/ubuntu/www/static/"
 STATIC_URL = '/static/'
 
 # CORS config

--- a/dj_hetmech/settings.py
+++ b/dj_hetmech/settings.py
@@ -138,7 +138,7 @@ USE_TZ = True
 
 # Static files (CSS, JavaScript, Images)
 # https://docs.djangoproject.com/en/2.1/howto/static-files/
-
+STATIC_ROOT = "/home/ubuntu/hetmech-backend/dj_hetmech/static/"
 STATIC_URL = '/static/'
 
 # CORS config


### PR DESCRIPTION
This PR defines the directory for static files (which will be used by `manage.py collectstatic` management command to collect all static files in `INSTALLED_APPS`). But there is no need to keep track of these static files in the repo.