### PR TITLE
Deployment script

### DIFF
--- a/deployment/README.md
+++ b/deployment/README.md
@@ -1,0 +1,27 @@
+# Deployment
+
+This directory includes a shell script `setup.sh` and a few configuration files
+for packages that are required for hetmech backend deployment.
+
+## Prerequisites of Deployment Box:
+ - OS: Ubuntu 18.04
+ - Path of a Django secrets file (default name is `secrets.yml`)
+ - User account `ubuntu` that has `sudo` privilege
+
+## Deployment Steps:
+
+Type the following command on the deplyment box:
+```shell
+./setup.sh
+```
+
+Here is a summary of what this script does:
+ - Install/configure Nginx web server
+ - Install SSL certificate (issued by Let's Encrypt)
+ - Install a daily cron job to upgrade packages using `apt` command
+ - Install/configure Miniconda
+ - Download hetmech-backend code from Github and create a Conda environment
+ - Install/configure `supervisord`, which runs `Gunicorn` as a daemon
+
+Please reboot the deployment box at the end to ensure that the new
+configurations will become effective.

--- a/deployment/README.md
+++ b/deployment/README.md
@@ -4,7 +4,7 @@ This directory includes a shell script `setup.sh` and a few configuration files
 for packages that are required for hetmech backend deployment.
 
 ## Prerequisites of Deployment Box:
- - OS: Ubuntu 18.04
+ - OS: Ubuntu 18.04 or later
  - Path of a Django secrets file (default name is `secrets.yml`)
  - User account `ubuntu` that has `sudo` privilege
 
@@ -17,7 +17,7 @@ Type the following command on the deplyment box:
 
 Here is a summary of what this script does:
  - Install/configure Nginx web server
- - Install SSL certificate (issued by Let's Encrypt)
+ - Install SSL certificate (issued by [Let's Encrypt](https://letsencrypt.org/))
  - Install a daily cron job to upgrade packages using `apt` command
  - Install/configure Miniconda
  - Download hetmech-backend code from Github and create a Conda environment

--- a/deployment/README.md
+++ b/deployment/README.md
@@ -1,7 +1,6 @@
 # Deployment
 
-This directory includes a shell script `setup.sh` and a few configuration files
-for packages that are required for hetmech backend deployment.
+This directory includes a shell script `setup.sh` and a few configuration files for packages that are required for hetmech backend deployment.
 
 ## Prerequisites of Deployment Box:
  - OS: Ubuntu 18.04 or later
@@ -23,5 +22,4 @@ Here is a summary of what this script does:
  - Download hetmech-backend code from Github and create a Conda environment
  - Install/configure `supervisord`, which runs `Gunicorn` as a daemon
 
-Please reboot the deployment box at the end to ensure that the new
-configurations will become effective.
+Please reboot the deployment box at the end to ensure that the new configurations will become effective.

--- a/deployment/bashrc_conda
+++ b/deployment/bashrc_conda
@@ -1,0 +1,4 @@
+# Make sure that "conda" command is available
+if [ -f ~/miniconda3/etc/profile.d/conda.sh ]; then
+    source ~/miniconda3/etc/profile.d/conda.sh
+fi

--- a/deployment/bashrc_conda
+++ b/deployment/bashrc_conda
@@ -1,4 +1,0 @@
-# Make sure that "conda" command is available
-if [ -f ~/miniconda3/etc/profile.d/conda.sh ]; then
-    source ~/miniconda3/etc/profile.d/conda.sh
-fi

--- a/deployment/gunicorn.conf
+++ b/deployment/gunicorn.conf
@@ -1,0 +1,10 @@
+[program:hetmech-gunicorn]
+command=/home/ubuntu/miniconda3/envs/hetmech-backend/bin/gunicorn dj_hetmech.wsgi:application --bind 127.0.0.1:8001 --error-logfile /tmp/hetmech-g
+unicorn.log -w 3
+directory=/home/ubuntu/hetmech-backend/
+user=nobody
+group=nobody
+autostart=true
+autorestart=true
+priority=991
+stopsignal=KILL

--- a/deployment/gunicorn.conf
+++ b/deployment/gunicorn.conf
@@ -1,6 +1,5 @@
 [program:hetmech-gunicorn]
-command=/home/ubuntu/miniconda3/envs/hetmech-backend/bin/gunicorn dj_hetmech.wsgi:application --bind 127.0.0.1:8001 --error-logfile /tmp/hetmech-g
-unicorn.log -w 3
+command=/home/ubuntu/miniconda/envs/hetmech-backend/bin/gunicorn dj_hetmech.wsgi:application --bind 127.0.0.1:8001 --error-logfile /tmp/hetmech-gunicorn.log -w 3
 directory=/home/ubuntu/hetmech-backend/
 user=nobody
 group=nobody

--- a/deployment/gunicorn.conf
+++ b/deployment/gunicorn.conf
@@ -1,5 +1,5 @@
 [program:hetmech-gunicorn]
-command=/home/ubuntu/miniconda/envs/hetmech-backend/bin/gunicorn dj_hetmech.wsgi:application --bind 127.0.0.1:8001 --error-logfile /tmp/hetmech-gunicorn.log -w 3
+command=/home/ubuntu/miniconda/envs/hetmech-backend/bin/gunicorn dj_hetmech.wsgi:application --bind 127.0.0.1:8001 --error-logfile /tmp/hetmech-gunicorn.log --workers=3
 directory=/home/ubuntu/hetmech-backend/
 user=nobody
 group=nobody

--- a/deployment/hetmech-api.conf
+++ b/deployment/hetmech-api.conf
@@ -1,0 +1,44 @@
+# HTTP configuration
+# Default HTTP server: always redirect to HTTPS
+server {
+    listen 80 default_server;
+    server_name _;
+    return 301 https://$host$request_uri;
+}
+
+# HTTPS server
+server {
+    listen 443;
+    server_name search-api.het.io;
+
+    if ( $http_host !~* ^(search-api\.het\.io)$ ) {
+        return 444;
+    }
+
+    ssl on;
+    ssl_certificate /etc/letsencrypt/live/search-api.het.io/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/search-api.het.io/privkey.pem;
+
+    charset utf-8;
+
+    # max upload size (adjust to taste)
+    client_max_body_size 10M;
+
+    location / {
+        #alias /home/ubuntu/www/;
+        return 301 $scheme://$host/v1;
+    }
+
+   location /static {
+       alias /home/ubuntu/www/static;
+    }
+
+    location /v1 {
+        proxy_pass http://127.0.0.1:8001/v1;
+        proxy_set_header X-Forwarded-Host $server_name;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        add_header P3P 'CP="ALL DSP COR PSAa PSDa OUR NOR ONL UNI COM NAV"';
+    }
+
+}

--- a/deployment/hetmech-api.conf
+++ b/deployment/hetmech-api.conf
@@ -25,12 +25,11 @@ server {
     client_max_body_size 10M;
 
     location / {
-        #alias /home/ubuntu/www/;
         return 301 $scheme://$host/v1;
     }
 
-   location /static {
-       alias /home/ubuntu/www/static;
+    location /static {
+        alias /home/ubuntu/www/static;
     }
 
     location /v1 {

--- a/deployment/setup.sh
+++ b/deployment/setup.sh
@@ -64,8 +64,6 @@ fi
 # Build Django app
 cd ~/hetmech-backend
 python manage.py collectstatic --clear --no-input
-python manage.py makemigrations dj_hetmech_app
-python manage.py migrate
 
 # Restart Gunicorn and Nginx
 sudo /etc/init.d/supervisor restart

--- a/deployment/setup.sh
+++ b/deployment/setup.sh
@@ -52,16 +52,14 @@ source ~/miniconda/etc/profile.d/conda.sh
 conda env create --quiet --file ~/hetmech-backend/environment.yml
 conda activate hetmech-backend
 
-# Build "static" directory (used by API view in HTML format)
-mkdir -p ~/www/static
-chmod 755 ~/www/ ~/www/static/
-
 # Copy $DJ_SECRETS_FILE as ~/hetmech-backend/dj_hetmech/secrets.yml
 if ! [ -f ~/hetmech-backend/dj_hetmech/secrets.yml ]; then
     cp $DJ_SECRETS_FILE ~/hetmech-backend/dj_hetmech/secrets.yml
 fi
 
-# Build Django app
+# Create and populate "static" directory (for API view in HTML format)
+mkdir -p ~/www/static/
+chmod 755 ~/www/ ~/www/static/
 cd ~/hetmech-backend
 python manage.py collectstatic --clear --no-input
 

--- a/deployment/setup.sh
+++ b/deployment/setup.sh
@@ -36,12 +36,14 @@ apt install gcc --yes  # gcc is required by "pip install git+https://..."
 cd && git clone https://github.com/greenelab/hetmech-backend.git
 cd hetmech-backend
 conda env create --quiet --file environment.yml
-python manage.py makemigrations dj_hetmech_app
-python manage.py migrate
+conda activate hetmech-backend
 
 # "static" directory (used by API view in HTML format)
 mkdir -p ~/www/static && chmod -R 755 ~/www/
 python manage.py collectstatic
+
+python manage.py makemigrations dj_hetmech_app
+python manage.py migrate
 
 # Use supervisord to take care of Gunicorn daemon
 sudo apt install supervisor --yes

--- a/deployment/setup.sh
+++ b/deployment/setup.sh
@@ -2,7 +2,7 @@
 
 # This script should be run as user "ubuntu" only.
 if [ `whoami` != 'ubuntu' ]; then
-    echo "Error: current user is not ubuntu!"
+    echo "Error: current user is not 'ubuntu'"
     exit
 fi
 
@@ -24,28 +24,32 @@ sudo certbot --nginx certonly
 sudo rm -f /etc/nginx/sites-enabled/default
 sudo cp hetmech-api.conf /etc/nginx/sites-available/
 sudo ln -s /etc/nginx/sites-available/hetmech-api.conf /etc/nginx/sites-enabled/
-sudo /etc/init.d/nginx restart
-
-# Miniconda environment setup
-sudo apt install git wget python3 python3-pip --yes
-wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh --output-document miniconda.sh
-bash miniconda.sh -b -p ~/miniconda
-cat bashrc_conda >> ~/.bashrc && source ~/.bashrc
-apt install gcc --yes  # gcc is required by "pip install git+https://..."
-
-cd && git clone https://github.com/greenelab/hetmech-backend.git
-cd hetmech-backend
-conda env create --quiet --file environment.yml
-conda activate hetmech-backend
-
-# "static" directory (used by API view in HTML format)
-mkdir -p ~/www/static && chmod -R 755 ~/www/
-python manage.py collectstatic
-
-python manage.py makemigrations dj_hetmech_app
-python manage.py migrate
 
 # Use supervisord to take care of Gunicorn daemon
 sudo apt install supervisor --yes
 sudo cp gunicorn.conf /etc/supervisor/conf.d/
+
+# Miniconda environment setup
+sudo apt install git wget python3 python3-pip gcc --yes
+wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh --output-document ~/miniconda.sh
+bash ~/miniconda.sh -b -p ~/miniconda
+echo "source ~/miniconda/etc/profile.d/conda.sh" >> ~/.bashrc
+
+rm -rf ~/hetmech-backend
+git clone https://github.com/greenelab/hetmech-backend.git ~/hetmech-backend
+source ~/miniconda/etc/profile.d/conda.sh
+conda env create --quiet --file ~/hetmech-backend/environment.yml
+conda activate hetmech-backend
+
+# Build "static" directory (used by API view in HTML format)
+mkdir -p ~/www/static && chmod 755 ~/www/ ~/www/static
+
+# Copy "secrets.yml" into ~/hetmech-backend/dj_hetmech/, then continue
+cd ~/hetmech-backend
+python manage.py collectstatic --clear --no-input
+python manage.py makemigrations dj_hetmech_app
+python manage.py migrate
+
+# Restart Gunicorn and Nginx
 sudo /etc/init.d/supervisor restart
+sudo /etc/init.d/nginx restart

--- a/deployment/setup.sh
+++ b/deployment/setup.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+
+# This script should be run as user "ubuntu" only.
+if [ `whoami` != 'ubuntu' ]; then
+    echo "Error: current user is not ubuntu!"
+    exit
+fi
+
+# Update packages automatically using a daily cron job
+sudo apt update
+sudo apt purge unattended-upgrades --yes
+sudo rm -rf /var/log/unattended-upgrades/
+sudo cp upgrade-pkg /etc/cron.daily/
+sudo chmod 755 /etc/cron.daily/upgrade-pkg
+
+# Nginx config
+sudo apt install nginx --yes
+# Install SSL certificates issued by Let's Encrypt
+sudo add-apt-repository ppa:certbot/certbot --yes
+sudo apt update
+sudo apt install certbot python-certbot-nginx --yes
+sudo certbot --nginx certonly
+
+sudo rm -f /etc/nginx/sites-enabled/default
+sudo cp hetmech-api.conf /etc/nginx/sites-available/
+sudo ln -s /etc/nginx/sites-available/hetmech-api.conf /etc/nginx/sites-enabled/
+sudo /etc/init.d/nginx restart
+
+# Miniconda environment setup
+sudo apt install git wget python3 python3-pip --yes
+wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh --output-document miniconda.sh
+bash miniconda.sh -b -p ~/miniconda
+cat bashrc_conda >> ~/.bashrc && source ~/.bashrc
+apt install gcc --yes  # gcc is required by "pip install git+https://..."
+
+cd && git clone https://github.com/greenelab/hetmech-backend.git
+cd hetmech-backend
+conda env create --quiet --file environment.yml
+python manage.py makemigrations dj_hetmech_app
+python manage.py migrate
+
+# "static" directory (used by API view in HTML format)
+mkdir -p ~/www/static && chmod -R 755 ~/www/
+python manage.py collectstatic
+
+# Use supervisord to take care of Gunicorn daemon
+sudo apt install supervisor --yes
+sudo cp gunicorn.conf /etc/supervisor/conf.d/
+sudo /etc/init.d/supervisor restart

--- a/deployment/upgrade-pkg
+++ b/deployment/upgrade-pkg
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+# Upgrade packages and reboot the system if required.
+apt update
+DEBIAN_FRONTEND=noninteractive apt full-upgrade --yes
+apt autoremove --yes
+
+if [ -f /var/run/reboot-required ]; then
+    /sbin/reboot
+fi


### PR DESCRIPTION
This PR includes a shell script (and related configuration files) that will deploy hetmech-backend API web server on a vanilla Ubuntu 18.04 box. I am using it to keep track of all deployment steps for now.