### PR TITLE
Enable inverted path score lookup in get_paths

### DIFF
--- a/dj_hetmech_app/utils/paths.py
+++ b/dj_hetmech_app/utils/paths.py
@@ -12,7 +12,7 @@ from dj_hetmech_app.utils import (
 
 def get_paths(metapath, source_id, target_id, limit=None):
     """
-    Return JSON-serializable object with paths between two nodes for a given metapath.
+    Return JSON-serializeable object with paths between two nodes for a given metapath.
     """
     metagraph = get_hetionet_metagraph()
     metapath = metagraph.get_metapath(metapath)

--- a/dj_hetmech_app/utils/paths.py
+++ b/dj_hetmech_app/utils/paths.py
@@ -18,12 +18,16 @@ def get_paths(metapath, source_id, target_id, limit=None):
     metapath = metagraph.get_metapath(metapath)
 
     from dj_hetmech_app.models import Node, PathCount
+    from django.db.models import Q
     source_record = Node.objects.get(pk=source_id)
     target_record = Node.objects.get(pk=target_id)
     source_identifier = source_record.get_cast_identifier()
     target_identifier = target_record.get_cast_identifier()
     try:
-        metapath_record = PathCount.objects.get(metapath=metapath.abbrev, source=source_id, target=target_id)
+        metapath_record = PathCount.objects.get(
+            Q(metapath=metapath.abbrev, source=source_id, target=target_id) |
+            Q(metapath=metapath.inverse.abbrev, source=target_id, target=source_id)
+        )
     except PathCount.DoesNotExist:
         metapath_record = None
     if metapath_record and metapath_record.p_value:


### PR DESCRIPTION
Error occurred at:
https://search-api.het.io/v1/query-paths/?source=20673&target=9470&metapath=DtCcSEcC

Tested fix locally:
http://localhost:8000/v1/query-metapaths/?source=20673&target=9470&metapath=DtCcSEcC