### PR TITLE
deployment: git pull fast-forward only

### DIFF
--- a/.circleci/deploy.sh
+++ b/.circleci/deploy.sh
@@ -6,7 +6,7 @@ git checkout master
 ENV_FILE="environment.yml"
 git remote update
 ENV_DIFF=`git diff origin $ENV_FILE`
-git pull
+git pull --ff-only
 
 # Update conda env if needed
 if [ -n "$ENV_DIFF" ]; then


### PR DESCRIPTION
Prevents backend from breaking in case of merge conflicts as
happened in https://github.com/greenelab/hetmech-backend/issues/53#issuecomment-497088682