### PR TITLE
query-paths: compute path_count for on-the-fly rows

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -22,6 +22,6 @@ dependencies:
   - scipy=1.2.1
   - sqlparse=0.3.0
   - pip:
-    - git+https://github.com/hetio/hetnetpy@43294c38cfbc61ede93d6621188a8de2143decac
+    - git+https://github.com/hetio/hetnetpy@4edea3e4cc401377a03bf4e62ebf38cabce16f5a
     - git+https://github.com/hetio/hetmatpy@2589aa32abf73d70451c101d7bd9df425b357a7b
     - markdown==3.1


### PR DESCRIPTION
Closes https://github.com/greenelab/hetmech-backend/issues/64

Tested locally with
http://localhost:8000/v1/query-paths/?source=17054&target=6602&metapath=CbGcGaD

The response was:

<details>

```json
{
    "query": {
        "source_id": 17054,
        "target_id": 6602,
        "source_metanode": "Compound",
        "target_metanode": "Disease",
        "source_identifier": "DB00331",
        "target_identifier": "DOID:1612",
        "metapath": "CbGcGaD",
        "metapath_id": [
            [
                "Compound",
                "Gene",
                "binds",
                "both"
            ],
            [
                "Gene",
                "Gene",
                "covaries",
                "both"
            ],
            [
                "Gene",
                "Disease",
                "associates",
                "both"
            ]
        ],
        "metapath_unadjusted_p_value": 0.4520701251633918,
        "metapath_adjusted_p_value": 1.0,
        "metapath_score": -0.0,
        "limit": 100
    },
    "path_count_info": {
        "id": null,
        "adjusted_p_value": 1.0,
        "path_count": 1,
        "dwpc": 2.62669433477876,
        "p_value": 0.4520701251633918,
        "source": 17054,
        "target": 6602,
        "reversed": false,
        "metapath_abbreviation": "CbGcGaD",
        "metapath_name": "Compound–binds–Gene–covaries–Gene–associates–Disease",
        "metapath_length": 3,
        "metapath_path_count_density": 0.114583,
        "metapath_path_count_mean": 0.162757,
        "metapath_path_count_max": 19,
        "metapath_dwpc_raw_mean": 5.68893e-05,
        "metapath_n_similar": 121,
        "metapath_p_threshold": 0.0010420797311769,
        "metapath_source": "Compound",
        "metapath_target": "Disease",
        "metapath_id": "CbGcGaD",
        "metapath_reversed": false,
        "metapath_metaedges": [
            [
                "Compound",
                "Gene",
                "binds",
                "both"
            ],
            [
                "Gene",
                "Gene",
                "covaries",
                "both"
            ],
            [
                "Gene",
                "Disease",
                "associates",
                "both"
            ]
        ],
        "dgp_id": 21669569,
        "dgp_source_degree": 56,
        "dgp_target_degree": 540,
        "dgp_n_dwpcs": 200,
        "dgp_n_nonzero_dwpcs": 199,
        "dgp_nonzero_mean": 2.63321394104185,
        "dgp_nonzero_sd": 0.956905851784067,
        "dgp_reversed": false,
        "cypher_query": "MATCH path = (n0:Compound)-[:BINDS_CbG]-(n1)-[:COVARIES_GcG]-(n2)-[:ASSOCIATES_DaG]-(n3:Disease)\nUSING JOIN ON n1\nWHERE n0.identifier = 'DB00331' // Metformin\nAND n3.identifier = 'DOID:1612' // breast cancer\nAND n1 <> n2\nWITH\n[\nsize((n0)-[:BINDS_CbG]-()),\nsize(()-[:BINDS_CbG]-(n1)),\nsize((n1)-[:COVARIES_GcG]-()),\nsize(()-[:COVARIES_GcG]-(n2)),\nsize((n2)-[:ASSOCIATES_DaG]-()),\nsize(()-[:ASSOCIATES_DaG]-(n3))\n] AS degrees, path\nWITH path, reduce(pdp = 1.0, d in degrees| pdp * d ^ -0.5) AS PDP\nWITH collect({paths: path, PDPs: PDP}) AS data_maps, count(path) AS PC, sum(PDP) AS DWPC\nUNWIND data_maps AS data_map\nWITH data_map.paths AS path, data_map.PDPs AS PDP, PC, DWPC\nRETURN\n  path AS neo4j_path,\n  substring(reduce(s = '', node IN nodes(path)| s + '–' + node.name), 1) AS path,\n  PDP,\n  100 * (PDP / DWPC) AS percent_of_DWPC\nORDER BY percent_of_DWPC DESC\nLIMIT 10"
    },
    "paths": [
        {
            "metapath": "CbGcGaD",
            "node_ids": [
                17054,
                40162,
                28676,
                6602
            ],
            "rel_ids": [
                545803,
                249701,
                111805
            ],
            "PDP": 0.00039127511792986884,
            "percent_of_DWPC": 100.0,
            "score": -0.0
        }
    ],
    "nodes": {
        "6602": {
            "neo4j_id": 6602,
            "node_label": "Disease",
            "properties": {
                "name": "breast cancer",
                "source": "Disease Ontology",
                "identifier": "DOID:1612",
                "url": "http://purl.obolibrary.org/obo/DOID_1612",
                "license": "CC BY 3.0"
            },
            "metanode": "Disease"
        },
        "17054": {
            "neo4j_id": 17054,
            "node_label": "Compound",
            "properties": {
                "name": "Metformin",
                "source": "DrugBank",
                "identifier": "DB00331",
                "url": "http://www.drugbank.ca/drugs/DB00331",
                "license": "CC BY-NC 4.0",
                "inchi": "InChI=1S/C4H11N5/c1-9(2)4(7)8-3(5)6/h1-2H3,(H5,5,6,7,8)",
                "inchikey": "InChIKey=XZWYZXLIPXDOLR-UHFFFAOYSA-N"
            },
            "metanode": "Compound"
        },
        "28676": {
            "neo4j_id": 28676,
            "node_label": "Gene",
            "properties": {
                "name": "KCNN4",
                "source": "Entrez Gene",
                "identifier": 3783,
                "url": "http://identifiers.org/ncbigene/3783",
                "description": "potassium channel, calcium activated intermediate/small conductance subfamily N alpha, member 4",
                "license": "CC0 1.0",
                "chromosome": "19"
            },
            "metanode": "Gene"
        },
        "40162": {
            "neo4j_id": 40162,
            "node_label": "Gene",
            "properties": {
                "name": "SLC22A3",
                "source": "Entrez Gene",
                "identifier": 6581,
                "url": "http://identifiers.org/ncbigene/6581",
                "description": "solute carrier family 22 (organic cation transporter), member 3",
                "license": "CC0 1.0",
                "chromosome": "6"
            },
            "metanode": "Gene"
        }
    },
    "relationships": {
        "111805": {
            "neo4j_id": 111805,
            "rel_type": "ASSOCIATES_DaG",
            "source_neo4j_id": 6602,
            "target_neo4j_id": 28676,
            "properties": {
                "license": "CC BY 4.0",
                "sources": [
                    "GWAS Catalog"
                ],
                "unbiased": true
            },
            "kind": "associates",
            "directed": false
        },
        "249701": {
            "neo4j_id": 249701,
            "rel_type": "COVARIES_GcG",
            "source_neo4j_id": 40162,
            "target_neo4j_id": 28676,
            "properties": {
                "source": "ERC",
                "unbiased": true
            },
            "kind": "covaries",
            "directed": false
        },
        "545803": {
            "neo4j_id": 545803,
            "rel_type": "BINDS_CbG",
            "source_neo4j_id": 17054,
            "target_neo4j_id": 40162,
            "properties": {
                "license": "CC BY-NC 4.0",
                "actions": [
                    "substrate"
                ],
                "unbiased": false,
                "sources": [
                    "DrugBank (transporter)"
                ],
                "pubmed_ids": [
                    "16263091"
                ]
            },
            "kind": "binds",
            "directed": false
        }
    }
}
```

</details>