### PR TITLE
Put two Django settings in secrets.yml

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,9 +17,9 @@ Then use `conda activate hetmech-backend` and `conda deactivate` to activate or 
 
 ## Secrets
 
-Users must supply `dj_hetmech/secrets.yml` with the database connection information.
+Users must supply `dj_hetmech/secrets.yml` with the database connection information and two optional parameters for Django settings.
 See [`dj_hetmech/secrets-template.yml`](dj_hetmech/secrets-template.yml) for what fields should be defined.
-These secrets will determine whether django connects to a local database or a remote database.
+These secrets will determine whether django connects to a local database or a remote database and other security settings in Django.
 
 ## Notebooks
 

--- a/dj_hetmech/secrets-template.yml
+++ b/dj_hetmech/secrets-template.yml
@@ -4,3 +4,14 @@ db:
   password: not_secure
   host: database_hostname
   port: database_port_number
+
+##################################################################
+#     Optional Django settings
+##################################################################
+# `SECRET_KEY` defaults to 'secret_not_yet_set' in `settings.py`.
+# For production server, set it to a long random string.
+SECRET_KEY: 'secret_not_yet_set'
+
+# `DEBUG` defaults to True in `settings.py`.
+# For production server, set it to False.
+DEBUG: True

--- a/dj_hetmech/settings.py
+++ b/dj_hetmech/settings.py
@@ -26,10 +26,10 @@ with open(path) as read_file:
 # See https://docs.djangoproject.com/en/2.1/howto/deployment/checklist/
 
 # SECURITY WARNING: keep the secret key used in production secret!
-SECRET_KEY = 'secret_not_yet_set'
+SECRET_KEY = secrets.get('SECRET_KEY', 'secret_not_yet_set')
 
 # SECURITY WARNING: don't run with debug turned on in production!
-DEBUG = True
+DEBUG = secrets.get('DEBUG', True)
 
 ALLOWED_HOSTS = ['localhost', 'search-api.het.io', ]
 


### PR DESCRIPTION
This PR moves `SECRET_KEY` and `DEBUG` parameters in `settings.py` to `secrets.yml` to make the deployment more flexible and secure.